### PR TITLE
fix: rename user table from 'user' to 'users' to avoid reserved word …

### DIFF
--- a/src/main/java/com/vanessa/habitus/model/User.java
+++ b/src/main/java/com/vanessa/habitus/model/User.java
@@ -3,7 +3,7 @@ package com.vanessa.habitus.model;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 public class User {
 
     @Id


### PR DESCRIPTION
Renomeia a tabela 'user' para 'users' para evitar conflito com palavra reservada do banco de dados.